### PR TITLE
Add config option for "attribute"

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -4,7 +4,7 @@ const { JSDOM } = require('jsdom');
 const fetch = require('node-fetch');
 const sh = require('shorthash');
 
-let config = { distPath: '_site', verbose: false };
+let config = { distPath: '_site', verbose: false, attribute: 'src' };
 
 const downloadImage = async path => {
   if (config.verbose) {
@@ -27,7 +27,7 @@ const downloadImage = async path => {
 }
 
 const processImage = async img => {
-  let { distPath, assetPath, attribute = 'src' } = config;
+  let { distPath, assetPath, attribute } = config;
 
   const external = /https?:\/\/((?:[\w\d-]+\.)+[\w\d]{2,})/i;
   const imgPath = img.getAttribute(attribute);

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -27,10 +27,10 @@ const downloadImage = async path => {
 }
 
 const processImage = async img => {
-  let { distPath, assetPath } = config;
+  let { distPath, assetPath, attribute = 'src' } = config;
 
   const external = /https?:\/\/((?:[\w\d-]+\.)+[\w\d]{2,})/i;
-  const imgPath = img.getAttribute('src');
+  const imgPath = img.getAttribute(attribute);
 
   if (external.test(imgPath)) {
     try {
@@ -55,7 +55,7 @@ const processImage = async img => {
         }
 
         // Update the image with the new file path
-        img.setAttribute('src', path.join(assetPath, `${hash}-${filename}`));  
+        img.setAttribute(attribute, path.join(assetPath, `${hash}-${filename}`));  
       }
     } catch (error) {
       console.log(error);

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ module.exports = function(eleventyConfig) {
 | `distPath` | String | The output folder for your eleventy site, e.g. `'_site'`<br>__Required__ |
 | `assetPath` | String | The root-relative folder where your image assets are stored, e.g. `'/assets/img'`<br>__Required__ |
 | `selector` | String | The css selector for the images you wish to replace. This defaults to all images `'img'`, but could be used to fence certain images only, e.g. `'.post-content img'`<br>Default: `'img'` |
+| `attribute` | String | The attribute containing the image path. This defaults to `'src'`, but could be used to match other attributes, e.g. `'srcset'` if targeting a `<picture><source>`, or `'data-src'` if using a lazy-loading plugin<br>Default: `'src'` |
 | `verbose` | Boolean | Toggles console logging when images are saved locally<br>Default: `false` |
 
 ## Known issues


### PR DESCRIPTION
This PR adds a config value allowing users to define the HTML attribute containing the image path.

This value defaults to `'src'` but could be used to match other attributes; e.g. `'srcset'` if targeting a `<picture><source>`, or `'data-src'` if using a lazy-loading plugin (like [this one](https://github.com/liamfiddler/eleventy-plugin-lazyimages) 😉 ).