### PR TITLE
Checking if the file path has cache busting

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -49,7 +49,10 @@ const processImage = async img => {
     try {
       // get the filname from the path
       const pathComponents = imgPath.split('/');
-      let filename = pathComponents[pathComponents.length - 1];
+      
+      // break off cache busting string if there is one
+      let filename = pathComponents[pathComponents.length - 1].split("?");
+      filename = filename[0];
       
       // generate a unique short hash based on the original file path
       // this will prevent filename clashes


### PR DESCRIPTION
Netlify doesn't allow for `?` in filenames. Because the plugin names files from the name in the HTML the cached string on the end is being added to the filename.

Here I'm splitting the filename into an array wherever there's a `?` and only taking the first part. I think this is the best place to do so?