### PR TITLE
fix: false output path

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -93,7 +93,7 @@ const grabRemoteImages = async (rawContent, outputPath) => {
   let { selector = 'img' } = config;
   let content = rawContent;
 
-  if (outputPath.endsWith('.html')) {
+  if (outputPath && outputPath.endsWith('.html')) {
     const dom = new JSDOM(content);
     const images = [...dom.window.document.querySelectorAll(selector)];
 


### PR DESCRIPTION
## Description
When using `permalink: false`, the `outputPath` is false too. This behavior breaks the plugin with error `outputPath.endsWith is not a function`.
As you can see [here](https://github.com/11ty/11ty-website/pull/991/files), it is now mandatory to manage this case to avoid errors.

## How
Just check if `outputPath` is not `false` before checking it's end.