### PR TITLE
fix(getFileType): adapt to upstream API change

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -35,13 +35,13 @@ const downloadImage = async path => {
 
 const getFileType = (filename, buffer) => {
   // infer the file ext from the buffer
-  const type = fileType(buffer);
+  const type = fileType.fromBuffer(buffer);
 
   if (type.ext) {
     // return the filename with extension
     return `${filename}.${type.ext}`;
   } else {
-    throw new Error(`Couldn't infer file extension for "${path}"`);
+    throw new Error(`Couldn't infer file extension for "${filename}"`);
   }
 };
 


### PR DESCRIPTION
`file-type` seems to have changed their API - current master branch shows this error:

```
[0] TypeError: fileType is not a function
[0]     at getFileType (/Users/birkhoff/dev/11ty/third_party/eleventy-plugin-local-images/.eleventy.js:34:16)
[0]     at processImageAttr (/Users/birkhoff/dev/11ty/third_party/eleventy-plugin-local-images/.eleventy.js:86:26)
[0]     at processTicksAndRejections (node:internal/process/task_queues:96:5)
[0]     at async Promise.all (index 0)
[0]     at async processImage (/Users/birkhoff/dev/11ty/third_party/eleventy-plugin-local-images/.eleventy.js:47:3)
[0]     at async Promise.all (index 1)
[0]     at async Object.grabRemoteImages (/Users/birkhoff/dev/11ty/third_party/eleventy-plugin-local-images/.eleventy.js:125:7)
[0]     at async Template.runTransforms (/Users/birkhoff/dev/11ty/node_modules/@11ty/eleventy/src/Template.js:553:13)
[0]     at async Template.renderPageEntry (/Users/birkhoff/dev/11ty/node_modules/@11ty/eleventy/src/Template.js:848:15)
[0]     at async /Users/birkhoff/dev/11ty/node_modules/@11ty/eleventy/src/Template.js:872:21
```

After the change, the error goes away. Also fixed the variable name from `path` to `filename` in that `throw` statement.